### PR TITLE
⚠️ Fix future time parsing

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -49,7 +49,7 @@ number = { ASCII_DIGIT+ }
 
 /// Matches time unit expressions in singular or plural form (for example, "day" or
 /// "days").
-time_unit = { day_s | week_s | month_s | year_s }
+time_unit = _{ day_s | week_s | month_s | year_s }
 
 /// Day of the week: Monday or monday (case-insensitive).
 monday = { "Monday" | "monday" }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -49,7 +49,7 @@ number = { ASCII_DIGIT+ }
 
 /// Matches time unit expressions in singular or plural form (for example, "day" or
 /// "days").
-time_unit = _{ day_s | week_s | month_s | year_s }
+time_unit = _{ minute_s | hour_s | day_s | week_s | month_s | year_s }
 
 /// Day of the week: Monday or monday (case-insensitive).
 monday = { "Monday" | "monday" }
@@ -95,6 +95,12 @@ am = { "AM" | "am" }
 
 /// Time of day marker: PM or pm (case-insensitive).
 pm = { "PM" | "pm" }
+
+/// Singular or plural form of "minute".
+minute_s = { "minutes" | "minute" }
+
+/// Singular or plural form of "hour".
+hour_s = { "hours" | "hour" }
 
 /// Singular or plural form of "day".
 day_s = { "days" | "day" }

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -1,37 +1,37 @@
 /// Whitespace or tab
 WHITESPACE = _{ " " | "\t" }
 
-/// Parses a full date expression, which could be a relative date, 
+/// Parses a full date expression, which could be a relative date,
 /// specific day and time, or a future time phrase.
 /// - Examples: "next Monday", "tomorrow at 3:00 PM", "in 2 days"
-date_expression = { SOI ~ (relative_day_and_specific_time | relative_date | relative_term | specific_day_and_time | specific_day | specific_time | future_time ) ~ EOI }
+date_expression = { SOI ~ (relative_day_and_specific_time | relative_date | relative_term | specific_day_and_time | specific_day | specific_time | future_time) ~ EOI }
 
-/// Parses relative day expressions combined with specific times, such as 
+/// Parses relative day expressions combined with specific times, such as
 /// "tomorrow at 4:00 PM".
-relative_day_and_specific_time = { ( relative_date | relative_term ) ~ "at" ~ specific_time }
+relative_day_and_specific_time = { (relative_date | relative_term) ~ "at" ~ specific_time }
 
 /// Parses expressions for relative dates, for example, "next Tuesday" or "last Friday".
 relative_date = { next_or_last ~ specific_day }
 
-/// Parses terms representing days relative to today, including "tomorrow", 
+/// Parses terms representing days relative to today, including "tomorrow",
 /// "today", and "yesterday".
 relative_term = { tomorrow | today | yesterday }
 
-/// Parses expressions that specify both a day and a time, for example, "Wednesday 
+/// Parses expressions that specify both a day and a time, for example, "Wednesday
 /// at 5:00 AM".
 specific_day_and_time = { specific_day ~ "at" ~ specific_time }
 
 /// Parses specific days of the week, with case-insensitive options.
 specific_day = { monday | tuesday | wednesday | thursday | friday | saturday | sunday }
 
-/// Parses a specific time expression, including hour, minute, and AM/PM 
+/// Parses a specific time expression, including hour, minute, and AM/PM
 /// notation.
 specific_time = { hour ~ ":" ~ minute ~ am_pm | hour ~ am_pm }
 
 /// Parses future time expressions, such as "in 3 days" or "in 2 weeks".
 future_time = { "in" ~ number ~ time_unit }
 
-/// Matches relative terms for dates, allowing "next", "last", and "this" 
+/// Matches relative terms for dates, allowing "next", "last", and "this"
 /// qualifiers.
 next_or_last = { next | last | this }
 
@@ -47,7 +47,7 @@ am_pm = { am | pm }
 /// Parses a sequence of digits representing a number for time units.
 number = { ASCII_DIGIT+ }
 
-/// Matches time unit expressions in singular or plural form (for example, "day" or 
+/// Matches time unit expressions in singular or plural form (for example, "day" or
 /// "days").
 time_unit = { day_s | week_s | month_s | year_s }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub mod date_parser {
                         ParseDateError::ParseError("Invalid duration value".to_string())
                     })?;
                 }
-                Rule::time_unit => {
+                Rule::day_s | Rule::week_s | Rule::month_s | Rule::year_s => {
                     unit = Some(inner_pair.as_rule());
                 }
                 _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,12 @@ pub mod date_parser {
                         ParseDateError::ParseError("Invalid duration value".to_string())
                     })?;
                 }
-                Rule::day_s | Rule::week_s | Rule::month_s | Rule::year_s => {
+                Rule::minute_s
+                | Rule::hour_s
+                | Rule::day_s
+                | Rule::week_s
+                | Rule::month_s
+                | Rule::year_s => {
                     unit = Some(inner_pair.as_rule());
                 }
                 _ => {
@@ -154,6 +159,8 @@ pub mod date_parser {
 
         if let Some(unit) = unit {
             datetime = match unit {
+                Rule::minute_s => datetime + Duration::minutes(duration as i64),
+                Rule::hour_s => datetime + Duration::hours(duration as i64),
                 Rule::day_s => datetime + Duration::days(duration as i64),
                 Rule::week_s => datetime + Duration::weeks(duration as i64),
                 Rule::month_s => shift_months_opt(datetime, duration).ok_or_else(|| {

--- a/tests/processing_tests.rs
+++ b/tests/processing_tests.rs
@@ -263,7 +263,7 @@ mod tests {
                 .next()
                 .unwrap();
 
-            let result = process_relative_term(pair);
+            let result = process_relative_term(pair, Local::now());
             assert!(result.is_ok());
             assert_eq!(result.as_ref().unwrap().year(), expected_datetime.year());
             assert_eq!(result.as_ref().unwrap().month(), expected_datetime.month());
@@ -314,7 +314,7 @@ mod tests {
                 .next()
                 .unwrap();
 
-            let result = process_relative_date(pair);
+            let result = process_relative_date(pair, Local::now());
             println!("res {:#?}", result);
             assert!(result.is_ok());
 

--- a/tests/reference_tests.rs
+++ b/tests/reference_tests.rs
@@ -3,6 +3,30 @@ mod tests {
     use {chrono::prelude::*, natural_date_parser::date_parser};
 
     #[test]
+    fn test_in_15_minutes() {
+        assert_eq!(
+            date_parser::from_string_with_reference(
+                "in 15 minutes",
+                Local.with_ymd_and_hms(2025, 9, 7, 21, 0, 0).unwrap()
+            )
+            .unwrap(),
+            Local.with_ymd_and_hms(2025, 9, 7, 21, 15, 0).unwrap()
+        )
+    }
+
+    #[test]
+    fn test_in_1_hour() {
+        assert_eq!(
+            date_parser::from_string_with_reference(
+                "in 1 hour",
+                Local.with_ymd_and_hms(2025, 9, 7, 21, 0, 0).unwrap()
+            )
+            .unwrap(),
+            Local.with_ymd_and_hms(2025, 9, 7, 22, 0, 0).unwrap()
+        )
+    }
+
+    #[test]
     fn test_in_3_days() {
         assert_eq!(
             date_parser::from_string_with_reference(

--- a/tests/reference_tests.rs
+++ b/tests/reference_tests.rs
@@ -1,0 +1,52 @@
+#[cfg(test)]
+mod tests {
+    use {chrono::prelude::*, natural_date_parser::date_parser};
+
+    #[test]
+    fn test_in_3_days() {
+        assert_eq!(
+            date_parser::from_string_with_reference(
+                "in 3 days",
+                Local.with_ymd_and_hms(2025, 9, 7, 21, 0, 0).unwrap()
+            )
+            .unwrap(),
+            Local.with_ymd_and_hms(2025, 9, 10, 21, 0, 0).unwrap()
+        )
+    }
+
+    #[test]
+    fn test_in_5_weeks() {
+        assert_eq!(
+            date_parser::from_string_with_reference(
+                "in 5 weeks",
+                Local.with_ymd_and_hms(2025, 9, 7, 21, 0, 0).unwrap()
+            )
+            .unwrap(),
+            Local.with_ymd_and_hms(2025, 10, 12, 21, 0, 0).unwrap()
+        )
+    }
+
+    #[test]
+    fn test_in_2_months() {
+        assert_eq!(
+            date_parser::from_string_with_reference(
+                "in 2 months",
+                Local.with_ymd_and_hms(2025, 9, 7, 21, 0, 0).unwrap()
+            )
+            .unwrap(),
+            Local.with_ymd_and_hms(2025, 11, 7, 21, 0, 0).unwrap()
+        )
+    }
+
+    #[test]
+    fn test_in_12_years() {
+        assert_eq!(
+            date_parser::from_string_with_reference(
+                "in 12 years",
+                Local.with_ymd_and_hms(2025, 9, 7, 21, 0, 0).unwrap()
+            )
+            .unwrap(),
+            Local.with_ymd_and_hms(2037, 9, 7, 21, 0, 0).unwrap()
+        )
+    }
+}


### PR DESCRIPTION
The future_time rules were incorrectly processed, failing to support timespecs like "in 3 days".

In addition, extend the future_time rule to support minutes and hours.