### PR TITLE
Use canonical release-plz flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,53 @@
 name: Release
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   push:
     branches:
       - main
 
 jobs:
-  release-plz:
+  release-plz-release:
     name: Release-plz
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'koejdga' }}
+
+    permissions:
+      contents: write
 
     steps:
-      - name: Checkout repository
+      - &checkout
+        name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
+      - &install-rust
+        name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
-        uses: release-plz/action@v0.5.117
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - *checkout
+      - *install-rust
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Release-plz doesn't seem to support direct releasing anymore, so it will need to go through a PR flow, this PR adds the necessary steps.

Set up [Github Actions permmissions](https://release-plz.dev/docs/github/quickstart) and provide a CARGO_REGISTRY_TOKEN as described in [this PR](https://github.com/no111u3/avra-rs/pull/2).

After this, the merge to main will trigger a release-plz PR, which you need to review (and modify if necessary) and then merge, to trigger an actual crates.io release.